### PR TITLE
Adding ItemCode as an optional parameter to Core/Item and to base class BgIcpPrinter in method AddItem

### DIFF
--- a/ErpNet.FP.Core/Core/Item.cs
+++ b/ErpNet.FP.Core/Core/Item.cs
@@ -73,6 +73,7 @@
     /// </summary>
     public class Item
     {
+        public int ItemCode { get; set; } = 999;
         /// <summary>
         /// ItemType is the type of the item row
         /// </summary>

--- a/ErpNet.FP.Core/Drivers/BgDaisy/BgDaisyIslFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgDaisy/BgDaisyIslFiscalPrinter.Commands.cs
@@ -25,7 +25,8 @@
             TaxGroup taxGroup,
             decimal quantity = 0,
             decimal priceModifierValue = 0,
-            PriceModifierType priceModifierType = PriceModifierType.None)
+            PriceModifierType priceModifierType = PriceModifierType.None,
+            int ItemCode = 999)
         {
             if (department <= 0) 
             {

--- a/ErpNet.FP.Core/Drivers/BgDatecs/BgDatecsCIslFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgDatecs/BgDatecsCIslFiscalPrinter.Commands.cs
@@ -84,7 +84,8 @@
             TaxGroup taxGroup,
             decimal quantity = 0,
             decimal priceModifierValue = 0,
-            PriceModifierType priceModifierType = PriceModifierType.None)
+            PriceModifierType priceModifierType = PriceModifierType.None,
+            int ItemCode = 999)
         // Protocol [<L1>][<Lf><L2>]<Tab><TaxCd><[Sign]Price>[*<Qwan>][,Perc|;Abs]
         {
             var itemData = new StringBuilder();

--- a/ErpNet.FP.Core/Drivers/BgDatecs/BgDatecsPIslFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgDatecs/BgDatecsPIslFiscalPrinter.Commands.cs
@@ -42,7 +42,8 @@
             TaxGroup taxGroup,
             decimal quantity = 0,
             decimal priceModifierValue = 0,
-            PriceModifierType priceModifierType = PriceModifierType.None)
+            PriceModifierType priceModifierType = PriceModifierType.None,
+            int ItemCode = 999)
         // Protocol [<L1>][<Lf><L2>]<Tab><TaxCd><[Sign]Price>[*<Qwan>][,Perc|;Abs]
         {
             var itemData = new StringBuilder();

--- a/ErpNet.FP.Core/Drivers/BgDatecs/BgDatecsXIslFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgDatecs/BgDatecsXIslFiscalPrinter.Commands.cs
@@ -201,7 +201,8 @@
             TaxGroup taxGroup,
             decimal quantity = 0m,
             decimal priceModifierValue = 0m,
-            PriceModifierType priceModifierType = PriceModifierType.None)
+            PriceModifierType priceModifierType = PriceModifierType.None,
+            int ItemCode = 999)
         {
             string PriceModifierTypeToProtocolValue()
             {

--- a/ErpNet.FP.Core/Drivers/BgIcpFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgIcpFiscalPrinter.Commands.cs
@@ -181,13 +181,14 @@
             decimal quantity = 0m,
             decimal priceModifierValue = 0m,
             PriceModifierType priceModifierType = PriceModifierType.None,
-            bool reversalReceipt = false)
+            bool reversalReceipt = false,
+            int ItemCode = 999)
         {
             var itemData = new StringBuilder()
                 .Append(reversalReceipt ? "24" : "44")
                 .Append(uniqueSaleNumber)
                 .Append(IcpDecimal(quantity == 0m ? 1m : quantity, 8, 3))
-                .Append(IcpDecimal(999, 8, 0))
+                .Append(IcpDecimal(ItemCode, 8, 0))
                 .Append(IcpDecimal(unitPrice, 8, 2))
                 .Append(department.ToString("X"))
                 .Append(GetTaxGroupText(taxGroup))

--- a/ErpNet.FP.Core/Drivers/BgIcpFiscalPrinter.cs
+++ b/ErpNet.FP.Core/Drivers/BgIcpFiscalPrinter.cs
@@ -129,7 +129,8 @@
                             item.Quantity,
                             item.PriceModifierValue,
                             item.PriceModifierType,
-                            reversalReceipt);
+                            reversalReceipt,
+                            item.ItemCode);
                     }
                     catch (StandardizedStatusMessageException e)
                     {

--- a/ErpNet.FP.Core/Drivers/BgIncotex/BgIncotexIslFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgIncotex/BgIncotexIslFiscalPrinter.Commands.cs
@@ -124,7 +124,8 @@
             TaxGroup taxGroup,
             decimal quantity = 0,
             decimal priceModifierValue = 0,
-            PriceModifierType priceModifierType = PriceModifierType.None)
+            PriceModifierType priceModifierType = PriceModifierType.None,
+            int ItemCode = 999)
         {
             var itemData = new StringBuilder();
             if (department <= 0) 

--- a/ErpNet.FP.Core/Drivers/BgIslFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgIslFiscalPrinter.Commands.cs
@@ -236,7 +236,8 @@
             TaxGroup taxGroup,
             decimal quantity = 0,
             decimal priceModifierValue = 0,
-            PriceModifierType priceModifierType = PriceModifierType.None)
+            PriceModifierType priceModifierType = PriceModifierType.None,
+            int ItemCode = 999)
         {
             var itemData = new StringBuilder();
             if (department <= 0) {

--- a/ErpNet.FP.Core/Drivers/BgIslFiscalPrinter.cs
+++ b/ErpNet.FP.Core/Drivers/BgIslFiscalPrinter.cs
@@ -128,7 +128,8 @@
                                 item.TaxGroup,
                                 item.Quantity,
                                 item.PriceModifierValue,
-                                item.PriceModifierType);
+                                item.PriceModifierType,
+                                item.ItemCode);
                         }
                         catch (StandardizedStatusMessageException e)
                         {


### PR DESCRIPTION

The goal is for ISL printers to be able to use the ItemCode instead of the currently hard-coded '999' value.
The Reason:
 1. Some NRA agents are complaining about it, so minimizing time spent explaining.
 2. Some clients that use ISL printers do know the ItemCodes by heart and it's easy for them to scan the receipt for errors.