### PR TITLE
Fix: Department sell command (0x34) fails on Tremol ZFP devices with E401 Syntax Error

### DIFF
--- a/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.Commands.cs
@@ -208,10 +208,13 @@
             {
                 // Protocol: <NamePLU[36]><;><DepNum[1..2]><;><Price[1..10]>{<'*'>< Quantity[1..10]>}
                 //           {<','><DiscAddP[1..7]>}{<':'><DiscAddV[1..8]>}
+                // NOTE: department byte = (dept + 0x80) must be injected as raw byte,
+                // NOT as a char, because CP1251 does not map U+0082 etc. to those bytes.
+                // We use a placeholder char '~' here and replace it in the byte array below.
                 itemData
                     .Append(itemText.WithMaxLength(Info.ItemTextMaxLength).PadRight(ItemTextMandatoryLength))
                     .Append(';')
-                    .Append((department + 0x80).ToString("X2"))
+                    .Append('~')
                     .Append(';')
                     .Append(unitPrice.ToString("F2", CultureInfo.InvariantCulture));
             }
@@ -254,7 +257,17 @@
             }
             else
             {
-                return Request(CommandSellCorrectionDepartment, itemData.ToString());
+                // Encode to bytes then patch the placeholder '~' (0x7E) with the real dept byte
+                var rawData = PrinterEncoding.GetBytes(itemData.ToString());
+                for (int i = 0; i < rawData.Length; i++)
+                {
+                    if (rawData[i] == 0x7E) // '~' placeholder
+                    {
+                        rawData[i] = (byte)(department + 0x80);
+                        break;
+                    }
+                }
+                return RequestRaw(CommandSellCorrectionDepartment, rawData);
             }
         }
 

--- a/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.Frame.cs
+++ b/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.Frame.cs
@@ -345,6 +345,41 @@
             return new DeviceStatusWithRawResponse(status) { RawResponse = rawResponse };
         }
 
+        protected (string, DeviceStatus) RequestRaw(byte command, byte[] data)
+        {
+            lock (frameSyncLock)
+            {
+                if (DeadLine < DateTime.Now)
+                {
+                    var deviceStatus = new DeviceStatus();
+                    deviceStatus.AddError("E999", "User timeout occured while sending the request");
+                    return (string.Empty, deviceStatus);
+                }
+                try
+                {
+                    return ParseResponse(RawRequest(command, data));
+                }
+                catch (StandardizedStatusMessageException e)
+                {
+                    var deviceStatus = new DeviceStatus();
+                    deviceStatus.AddError(e.Code, e.Message);
+                    return (string.Empty, deviceStatus);
+                }
+                catch (InvalidResponseException e)
+                {
+                    var deviceStatus = new DeviceStatus();
+                    deviceStatus.AddError("E107", e.Message);
+                    return (string.Empty, deviceStatus);
+                }
+                catch (Exception e)
+                {
+                    var deviceStatus = new DeviceStatus();
+                    deviceStatus.AddError("E101", e.Message);
+                    return (string.Empty, deviceStatus);
+                }
+            }
+        }
+
         protected (string, DeviceStatus) Request(byte command, string? data = null)
         {
             lock (frameSyncLock)


### PR DESCRIPTION
## Problem

When `department > 0` is specified in a sale item, the `AddItem()` method in
`BgZfpFiscalPrinter.Commands.cs` builds the department field using:

```csharp
.Append((department + 0x80).ToString("X2"))
```

This appends the department as a **two-character hex string** (e.g. `"82"` for dept 2),
but the Tremol ZFP protocol requires a **single raw byte** with value `dept + 0x80`.

Even after fixing it to `(char)(department + 0x80)`, the result is still wrong because
Unicode code points U+0080–U+009F are C1 control characters that **do not exist in CP1251**.
`PrinterEncoding.GetBytes((char)0x82)` returns `0x3F` (`?`) — the fallback replacement
character — instead of `0x82`. The printer receives `?` and returns **E401 Syntax Error**.

## Root Cause

CP1251 does not have a 1:1 mapping for Unicode U+0080–U+009F. Those code points are
used for Cyrillic characters in CP1251 (e.g. `0x82` = `„`), so the encoding is
fundamentally asymmetric — you cannot round-trip through `char` for these values.

## Fix

Encode the item data string to bytes via `PrinterEncoding` first, then **patch the
department byte directly in the byte array** using a placeholder character `~` (0x7E)
that is safe in CP1251 and unlikely to appear in product names.

A new `RequestRaw(byte command, byte[] data)` overload is added to `Frame.cs` to
accept pre-encoded byte arrays directly, avoiding any further string encoding.

## Testing

Tested on:
- **Device:** Tremol FP-28
- **Firmware:** `Ver.1.04 TRP28 К.С.E7F4`
- **Protocol:** `bg.zk.zfp`
- **Connection:** USB-serial (`/dev/ttyACM0`)
- **Platform:** Raspberry Pi 4, Linux ARM64

`department=2` now correctly sends byte `0x82` on the wire. Sale is recorded under
department 2 in fiscal memory, confirmed via X-report showing department breakdown.

## Protocol Reference

Tremol ZFP protocol spec, Command `34h`:
```
input: <NameSale[36]> <;> <DepNo[1]> <;> <Price[1..10]> {<'*'> <Qty>} ...
DepNo: 1 symbol = dept number + 0x80  (Dep01=0x81, Dep02=0x82, ... Dep19=0x93)
```