### PR TITLE
Fix Tremol ZFP department sell - send raw DepNum byte (supersedes #202)

### DIFF
--- a/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.Commands.cs
@@ -192,7 +192,8 @@
             decimal priceModifierValue = 0,
             PriceModifierType priceModifierType = PriceModifierType.None)
         {
-            var itemData = new StringBuilder();
+            var itemData = new FrameBuilder(PrinterEncoding);
+
             if (department <= 0) 
             {
                 // Protocol: <NamePLU[36]><;><OptionVATClass[1]><;><Price[1..10]>{<'*'>< Quantity[1..10]>}
@@ -206,12 +207,15 @@
             }
             else
             {
-                // Protocol: <NamePLU[36]><;><DepNum[1..2]><;><Price[1..10]>{<'*'>< Quantity[1..10]>}
+                // Protocol: <NamePLU[36]><;><DepNum[1]><;><Price[1..10]>{<'*'>< Quantity[1..10]>}
                 //           {<','><DiscAddP[1..7]>}{<':'><DiscAddV[1..8]>}
                 itemData
                     .Append(itemText.WithMaxLength(Info.ItemTextMaxLength).PadRight(ItemTextMandatoryLength))
                     .Append(';')
-                    .Append((department + 0x80).ToString("X2"))
+                    // DepNum is one raw byte = dept + 0x80 (Dep01=0x81 ... Dep19=0x93).
+                    // Sent via FrameBuilder.Append(byte) to bypass CP1251 text encoding,
+                    // which cannot round-trip U+0080–U+009F through char.
+                    .Append((byte)(department + 0x80))
                     .Append(';')
                     .Append(unitPrice.ToString("F2", CultureInfo.InvariantCulture));
             }
@@ -222,6 +226,7 @@
                     .Append('*')
                     .Append(quantity.ToString(CultureInfo.InvariantCulture));
             }
+
             switch (priceModifierType)
             {
                 case PriceModifierType.DiscountPercent:
@@ -250,11 +255,11 @@
 
             if (department <= 0) 
             {
-                return Request(CommandSellCorrection, itemData.ToString());
+                return Request(CommandSellCorrection, itemData.ToArray());
             }
             else
             {
-                return Request(CommandSellCorrectionDepartment, itemData.ToString());
+                return Request(CommandSellCorrectionDepartment, itemData.ToArray());
             }
         }
 

--- a/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.Frame.cs
+++ b/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.Frame.cs
@@ -347,28 +347,37 @@
 
         protected (string, DeviceStatus) Request(byte command, string? data = null)
         {
+            return Request(command, data == null ? null : PrinterEncoding.GetBytes(data));
+        }
+
+        protected (string, DeviceStatus) Request(byte command, byte[]? data)
+        {
             lock (frameSyncLock)
             {
                 if (DeadLine < DateTime.Now)
                 {
                     var deviceStatus = new DeviceStatus();
                     deviceStatus.AddError("E999", "User timeout occured while sending the request");
+
                     return (string.Empty, deviceStatus);
                 }
+
                 try
                 {
-                    return ParseResponse(RawRequest(command, data == null ? null : PrinterEncoding.GetBytes(data)));
+                    return ParseResponse(RawRequest(command, data));
                 }
                 catch (StandardizedStatusMessageException e)
                 {
                     var deviceStatus = new DeviceStatus();
                     deviceStatus.AddError(e.Code, e.Message);
+
                     return (string.Empty, deviceStatus);
                 }
                 catch (InvalidResponseException e)
                 {
                     var deviceStatus = new DeviceStatus();
                     deviceStatus.AddError("E107", e.Message);
+
                     return (string.Empty, deviceStatus);
                 }
                 catch (FileNotFoundException)
@@ -379,6 +388,7 @@
                 {
                     var deviceStatus = new DeviceStatus();
                     deviceStatus.AddError("E101", e.Message);
+
                     return (string.Empty, deviceStatus);
                 }
             }

--- a/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.FrameBuilder.cs
+++ b/ErpNet.FP.Core/Drivers/BgZfpFiscalPrinter.FrameBuilder.cs
@@ -1,0 +1,64 @@
+﻿namespace ErpNet.FP.Core.Drivers
+{
+    using System.IO;
+    using System.Text;
+
+    public partial class BgZfpFiscalPrinter
+    {
+        /// <summary>
+        /// Builds a binary protocol payload that mixes encoded text segments with raw bytes.
+        /// Avoids the CP1251 round-trip problem for byte values in the U+0080–U+009F range.
+        /// </summary>
+        protected sealed class FrameBuilder
+        {
+            private readonly MemoryStream _buffer = new();
+            private readonly Encoding _encoding;
+
+            /// <summary>
+            /// Creates a new builder that encodes text segments using the
+            /// given encoding (typically the printer's CP1251 encoding).
+            /// </summary>
+            public FrameBuilder(Encoding encoding)
+            {
+                _encoding = encoding;
+            }
+
+            /// <summary>
+            /// Appends a text segment, encoded via the configured encoding.
+            /// </summary>
+            public FrameBuilder Append(string text)
+            {
+                var bytes = _encoding.GetBytes(text);
+                _buffer.Write(bytes, 0, bytes.Length);
+
+                return this;
+            }
+
+            /// <summary>
+            /// Appends a single character, encoded via the configured encoding.
+            /// </summary>
+            public FrameBuilder Append(char c)
+            {
+                var bytes = _encoding.GetBytes([c]);
+                _buffer.Write(bytes, 0, bytes.Length);
+
+                return this;
+            }
+
+            /// <summary>
+            /// Appends a single raw byte, bypassing the encoding entirely.
+            /// </summary>
+            public FrameBuilder Append(byte b)
+            {
+                _buffer.WriteByte(b);
+
+                return this;
+            }
+
+            /// <summary>
+            /// Returns the accumulated payload as a new byte array.
+            /// </summary>
+            public byte[] ToArray() => _buffer.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
DepNum must be sent as one raw byte (dept + 0x80), not as text. Adds FrameBuilder + Request(byte, byte[]?) overload.
Credit @cdmanbg.