### PR TITLE
Add invoice and credit note native support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,9 +13,9 @@
     <Authors>ErpNet and Contributors</Authors>
     <PackageLicenseFile>$(SolutionDir)LICENSE.txt</PackageLicenseFile>
     <Copyright>(c) ErpNet and Contributors</Copyright>
-    <AssemblyVersion>1.1.0.1690</AssemblyVersion>
-    <FileVersion>1.1.0.1690</FileVersion>
-    <Version>1.1.0.1690</Version>
+    <AssemblyVersion>1.1.0.1691</AssemblyVersion>
+    <FileVersion>1.1.0.1691</FileVersion>
+    <Version>1.1.0.1691</Version>
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
     <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>

--- a/ErpNet.FP.Core/Core/CreditNote.cs
+++ b/ErpNet.FP.Core/Core/CreditNote.cs
@@ -1,0 +1,48 @@
+namespace ErpNet.FP.Core
+{
+    /// <summary>
+    /// Represents a native credit note: a reversal printed in invoice mode against an
+    /// original invoice, carrying a recipient (buyer) block. Being a <see cref="ReversalReceipt"/>,
+    /// it reuses the existing reversal pipeline; drivers switch to invoice mode when the
+    /// reversal receipt is a <see cref="CreditNote"/>.
+    /// </summary>
+    public class CreditNote : ReversalReceipt, IInvoiceDocument
+    {
+        /// <summary>
+        /// The recipient (buyer) of the credit note.
+        /// </summary>
+        public Recipient? Recipient { get; set; }
+
+        /// <summary>
+        /// Optional person on the buyer side who received the goods/services.
+        /// Device-dependent (see <see cref="IInvoiceDocument.Receiver"/>).
+        /// </summary>
+        public string Receiver { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Optional person on the seller side who drew up the credit note.
+        /// Device-dependent (see <see cref="IInvoiceDocument.Issuer"/>).
+        /// </summary>
+        public string Issuer { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Caller-supplied credit note number. Its handling depends on
+        /// <see cref="DeviceInfo.CreditNoteNumberAssignment"/>: required, optional, or rejected.
+        /// </summary>
+        public string Number { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The number of the original invoice being credited. Always required.
+        /// Distinct from the inherited <see cref="ReversalReceipt.ReceiptNumber"/>, which is
+        /// the original fiscal receipt number.
+        /// </summary>
+        public string OriginalInvoiceNumber { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The serial number of the fiscal device that issued the original invoice, as printed on it.
+        /// Distinct from the inherited <see cref="ReversalReceipt.FiscalMemorySerialNumber"/> (the
+        /// original fiscal memory number). Some devices require it to print a credit note.
+        /// </summary>
+        public string FiscalDeviceSerialNumber { get; set; } = string.Empty;
+    }
+}

--- a/ErpNet.FP.Core/Core/DeviceInfo.cs
+++ b/ErpNet.FP.Core/Core/DeviceInfo.cs
@@ -59,6 +59,26 @@
         /// </summary>
         public bool SubTotalAmountModifiersRequireTaxGroup = false;
         /// <summary>
+        /// Expresses support of printing a native fiscal invoice (a receipt in invoice mode
+        /// with a recipient block) by the device.
+        /// </summary>
+        public bool SupportsInvoice = false;
+        /// <summary>
+        /// Expresses support of printing a native credit note (a reversal in invoice mode
+        /// against an original invoice) by the device.
+        /// </summary>
+        public bool SupportsCreditNote = false;
+        /// <summary>
+        /// Expresses how the invoice number is assigned: by the device, optionally by the caller,
+        /// or required from the caller (see <see cref="NumberAssignment"/>).
+        /// </summary>
+        public NumberAssignment InvoiceNumberAssignment = NumberAssignment.DeviceAssigned;
+        /// <summary>
+        /// Expresses how the credit note number is assigned: by the device, optionally by the caller,
+        /// or required from the caller (see <see cref="NumberAssignment"/>).
+        /// </summary>
+        public NumberAssignment CreditNoteNumberAssignment = NumberAssignment.DeviceAssigned;
+        /// <summary>
         /// Expresses support of payment terminal for current device model
         /// </summary>
         public bool SupportPaymentTerminal = false;

--- a/ErpNet.FP.Core/Core/DeviceStatus.cs
+++ b/ErpNet.FP.Core/Core/DeviceStatus.cs
@@ -150,6 +150,20 @@
             ReceiptAmount = info.ReceiptAmount;
             FiscalMemorySerialNumber = info.FiscalMemorySerialNumber;
         }
+
+    }
+
+    public class DeviceStatusWithInvoiceInfo : DeviceStatusWithReceiptInfo
+    {
+        /// <summary>
+        /// The invoice / credit note number.
+        /// </summary>
+        public string InvoiceNumber = string.Empty;
+
+        public DeviceStatusWithInvoiceInfo(DeviceStatus status, InvoiceInfo info) : base(status, info)
+        {
+            InvoiceNumber = info.InvoiceNumber;
+        }
     }
 
 }

--- a/ErpNet.FP.Core/Core/IFiscalPrinter.cs
+++ b/ErpNet.FP.Core/Core/IFiscalPrinter.cs
@@ -56,6 +56,28 @@ namespace ErpNet.FP.Core
         DeviceStatus ValidateReversalReceipt(ReversalReceipt reversalReceipt);
 
         /// <summary>
+        /// Prints a native invoice (an extended fiscal receipt with a recipient block).
+        /// Drivers that do not implement it return an E413 "not implemented" status.
+        /// </summary>
+        (ReceiptInfo, DeviceStatus) PrintInvoice(Invoice invoice);
+
+        /// <summary>
+        /// Validates the invoice object.
+        /// </summary>
+        DeviceStatus ValidateInvoice(Invoice invoice);
+
+        /// <summary>
+        /// Prints a native credit note (an extended fiscal reversal against an original invoice).
+        /// Drivers that do not implement it return an E413 "not implemented" status.
+        /// </summary>
+        (ReceiptInfo, DeviceStatus) PrintCreditNote(CreditNote creditNote);
+
+        /// <summary>
+        /// Validates the credit note object.
+        /// </summary>
+        DeviceStatus ValidateCreditNote(CreditNote creditNote);
+
+        /// <summary>
         /// Prints a deposit money note.
         /// </summary>
         /// <param name="amount">The deposited amount. Should be greater than 0.</param>

--- a/ErpNet.FP.Core/Core/IInvoiceDocument.cs
+++ b/ErpNet.FP.Core/Core/IInvoiceDocument.cs
@@ -1,0 +1,29 @@
+namespace ErpNet.FP.Core
+{
+    /// <summary>
+    /// Common contract for fiscal documents printed in invoice mode (a native invoice or a native credit note).
+    /// </summary>
+    public interface IInvoiceDocument
+    {
+        /// <summary>
+        /// The recipient (buyer) party.
+        /// </summary>
+        Recipient? Recipient { get; set; }
+
+        /// <summary>
+        /// Optional person on the buyer side who received the goods/services. Device-dependent.
+        /// </summary>
+        string Receiver { get; set; }
+
+        /// <summary>
+        /// Optional person on the seller side who drew up the document. Device-dependent.
+        /// </summary>
+        string Issuer { get; set; }
+
+        /// <summary>
+        /// Optional caller-supplied document number. Honored only by devices that support
+        /// external numbering; otherwise the device assigns the number itself.
+        /// </summary>
+        string Number { get; set; }
+    }
+}

--- a/ErpNet.FP.Core/Core/Invoice.cs
+++ b/ErpNet.FP.Core/Core/Invoice.cs
@@ -1,0 +1,33 @@
+namespace ErpNet.FP.Core
+{
+    /// <summary>
+    /// Represents a native fiscal invoice: a fiscal receipt printed in invoice mode,
+    /// carrying a recipient (buyer) block. Being a <see cref="Receipt"/>, it reuses the
+    /// existing print/validate pipeline; drivers switch to invoice mode when the receipt
+    /// is an <see cref="Invoice"/>.
+    /// </summary>
+    public class Invoice : Receipt, IInvoiceDocument
+    {
+        /// <summary>
+        /// The recipient (buyer) of the invoice.
+        /// </summary>
+        public Recipient? Recipient { get; set; }
+
+        /// <summary>
+        /// Optional person on the buyer side who received the goods/services. Device-dependent.
+        /// </summary>
+        public string Receiver { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Optional person on the seller side who drew up the invoice. Device-dependent.
+        /// </summary>
+        public string Issuer { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Caller-supplied invoice number. Its handling depends on
+        /// <see cref="DeviceInfo.InvoiceNumberAssignment"/>: required, optional, or rejected
+        /// (when the device assigns the number itself).
+        /// </summary>
+        public string Number { get; set; } = string.Empty;
+    }
+}

--- a/ErpNet.FP.Core/Core/InvoiceInfo.cs
+++ b/ErpNet.FP.Core/Core/InvoiceInfo.cs
@@ -1,0 +1,22 @@
+namespace ErpNet.FP.Core
+{
+    /// <summary>
+    /// Information returned after printing a native invoice or credit note.
+    /// Extends <see cref="ReceiptInfo"/> with the invoice / credit note number.
+    /// </summary>
+    public class InvoiceInfo : ReceiptInfo
+    {
+        /// <summary>
+        /// The invoice / credit note number, as actually printed. A driver MUST always populate this
+        /// on a successful invoice / credit note, regardless of numbering mode: echo the caller-supplied
+        /// number when it is external (<see cref="NumberAssignment.ExternalOptional"/> /
+        /// <see cref="NumberAssignment.ExternalRequired"/>), or read the assigned number back from the
+        /// device when it is <see cref="NumberAssignment.DeviceAssigned"/> - the consumer needs it in
+        /// the auto-assigned case, where it has no other way to learn the number.
+        /// </summary>
+        public string InvoiceNumber = string.Empty;
+
+        public override DeviceStatusWithReceiptInfo ToDeviceStatus(DeviceStatus status)
+            => new DeviceStatusWithInvoiceInfo(status, this);
+    }
+}

--- a/ErpNet.FP.Core/Core/NumberAssignment.cs
+++ b/ErpNet.FP.Core/Core/NumberAssignment.cs
@@ -1,0 +1,31 @@
+namespace ErpNet.FP.Core
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// Describes how the number of an invoice or credit note is assigned for a device.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum NumberAssignment
+    {
+        /// <summary>
+        /// The device assigns the number itself.
+        /// </summary>
+        [EnumMember(Value = "device-assigned")]
+        DeviceAssigned = 0,
+
+        /// <summary>
+        /// The caller may supply the number; when omitted, the device assigns it.
+        /// </summary>
+        [EnumMember(Value = "external-optional")]
+        ExternalOptional = 1,
+
+        /// <summary>
+        /// The caller must supply the number.
+        /// </summary>
+        [EnumMember(Value = "external-required")]
+        ExternalRequired = 2
+    }
+}

--- a/ErpNet.FP.Core/Core/ReceiptInfo.cs
+++ b/ErpNet.FP.Core/Core/ReceiptInfo.cs
@@ -21,5 +21,11 @@
         /// The fiscal memory number.
         /// </summary>
         public string FiscalMemorySerialNumber = string.Empty;
+
+        /// <summary>
+        /// Wraps <see cref="ReceiptInfo"/> into the flat device-status response returned to callers.
+        /// </summary>
+        public virtual DeviceStatusWithReceiptInfo ToDeviceStatus(DeviceStatus status)
+            => new DeviceStatusWithReceiptInfo(status, this);
     }
 }

--- a/ErpNet.FP.Core/Core/Recipient.cs
+++ b/ErpNet.FP.Core/Core/Recipient.cs
@@ -18,19 +18,22 @@ namespace ErpNet.FP.Core
         Unspecified = 0,
 
         /// <summary>
-        /// Legal registration identifier of an organization (e.g. company registration number).
+        /// Registration identifier of a domestic (resident) company. Drivers validate it against the
+        /// device's domestic scheme (e.g. a Bulgarian EIK / Bulstat), so a foreign number must NOT use
+        /// this type - use <see cref="ForeignerId"/> instead.
         /// </summary>
         [EnumMember(Value = "legal-registration")]
         LegalRegistration = 1,
 
         /// <summary>
-        /// National identification number of a person.
+        /// National identification number of a domestic (resident) natural person (e.g. a Bulgarian EGN).
         /// </summary>
         [EnumMember(Value = "national-id")]
         NationalId = 2,
 
         /// <summary>
-        /// Identification number of a foreign person (residence/personal number).
+        /// Identifier of a foreign (non-resident) party - company or natural person. Use for any
+        /// non-domestic buyer; the value may be alphanumeric.
         /// </summary>
         [EnumMember(Value = "foreigner-id")]
         ForeignerId = 3,

--- a/ErpNet.FP.Core/Core/Recipient.cs
+++ b/ErpNet.FP.Core/Core/Recipient.cs
@@ -1,0 +1,82 @@
+namespace ErpNet.FP.Core
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// The kind of legal identifier that identifies the recipient (buyer) party.
+    /// Country-neutral: each driver maps these to its device-specific codes.
+    /// </summary>
+    public enum IdentifierType
+    {
+        /// <summary>
+        /// No identifier type specified. Rejected when validating an invoice / credit note, so a
+        /// caller that omits the type gets a clear error instead of a silently-assumed value.
+        /// </summary>
+        [EnumMember(Value = "unspecified")]
+        Unspecified = 0,
+
+        /// <summary>
+        /// Legal registration identifier of an organization (e.g. company registration number).
+        /// </summary>
+        [EnumMember(Value = "legal-registration")]
+        LegalRegistration = 1,
+
+        /// <summary>
+        /// National identification number of a person.
+        /// </summary>
+        [EnumMember(Value = "national-id")]
+        NationalId = 2,
+
+        /// <summary>
+        /// Identification number of a foreign person (residence/personal number).
+        /// </summary>
+        [EnumMember(Value = "foreigner-id")]
+        ForeignerId = 3,
+
+        /// <summary>
+        /// Tax-authority-assigned number.
+        /// </summary>
+        [EnumMember(Value = "tax-number")]
+        TaxNumber = 4
+    }
+
+    /// <summary>
+    /// Represents the recipient (buyer) party of an invoice or credit note.
+    /// Field naming follows EN 16931 buyer terminology; drivers translate to device specifics.
+    /// </summary>
+    public class Recipient
+    {
+        /// <summary>
+        /// Buyer name (legal/registered name).
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Buyer legal registration identifier.
+        /// </summary>
+        public string Identifier { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The kind of <see cref="Identifier"/>. Must be specified for an invoice / credit note.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public IdentifierType IdentifierType { get; set; } = IdentifierType.Unspecified;
+
+        /// <summary>
+        /// Buyer VAT identifier.
+        /// </summary>
+        public string VatNumber { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Buyer postal address.
+        /// </summary>
+        public string Address { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Buyer city / town. Kept separate from <see cref="Address"/> because some devices require the city as a distinct field.
+        /// </summary>
+        public string City { get; set; } = string.Empty;
+    }
+}

--- a/ErpNet.FP.Core/Drivers/BgFiscalPrinter.cs
+++ b/ErpNet.FP.Core/Drivers/BgFiscalPrinter.cs
@@ -308,6 +308,110 @@
             return status;
         }
 
+        // Native invoice / credit note. The default implementations report "not implemented".
+        public virtual DeviceStatus ValidateInvoice(Invoice invoice) => NotImplemented("Invoice");
+
+        public virtual DeviceStatus ValidateCreditNote(CreditNote creditNote) => NotImplemented("Credit note");
+
+        public virtual (ReceiptInfo, DeviceStatus) PrintInvoice(Invoice invoice)
+            => (new ReceiptInfo(), NotImplemented("Invoice"));
+
+        public virtual (ReceiptInfo, DeviceStatus) PrintCreditNote(CreditNote creditNote)
+            => (new ReceiptInfo(), NotImplemented("Credit note"));
+
+        protected static DeviceStatus NotImplemented(string documentName)
+        {
+            var status = new DeviceStatus();
+            status.AddError("E413", $"{documentName} printing is not implemented by this driver");
+            return status;
+        }
+
+        /// <summary>
+        /// Reusable invoice validation for drivers that implement invoices.
+        /// </summary>
+        protected DeviceStatus ValidateInvoiceCore(Invoice invoice)
+        {
+            var status = ValidateReceipt(invoice);
+            if (!status.Ok)
+            {
+                return status;
+            }
+
+            ValidateInvoiceDocument(status, invoice, Info.InvoiceNumberAssignment, "Invoice");
+
+            return status;
+        }
+
+        /// <summary>
+        /// Reusable credit note validation for drivers that implement credit notes.
+        /// </summary>
+        protected DeviceStatus ValidateCreditNoteCore(CreditNote creditNote)
+        {
+            var status = ValidateReversalReceipt(creditNote);
+            if (!status.Ok)
+            {
+                return status;
+            }
+
+            ValidateInvoiceDocument(status, creditNote, Info.CreditNoteNumberAssignment, "Credit note");
+
+            if (string.IsNullOrEmpty(creditNote.OriginalInvoiceNumber))
+            {
+                status.AddError("E405", "OriginalInvoiceNumber of the credit note is empty");
+            }
+
+            return status;
+        }
+
+        /// <summary>
+        /// Validates the shared invoice-mode fields (recipient block and number assignment).
+        /// </summary>
+        protected void ValidateInvoiceDocument(
+            DeviceStatus status,
+            IInvoiceDocument document,
+            NumberAssignment numberAssignment,
+            string documentName)
+        {
+            var recipient = document.Recipient;
+            if (recipient == null)
+            {
+                status.AddError("E405", $"{documentName} requires a \"recipient\"");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(recipient.Name))
+            {
+                status.AddError("E405", "Recipient \"name\" is empty");
+            }
+
+            if (string.IsNullOrEmpty(recipient.Identifier))
+            {
+                status.AddError("E405", "Recipient \"identifier\" is empty");
+            }
+
+            if (recipient.IdentifierType == IdentifierType.Unspecified)
+            {
+                status.AddError("E405", "Recipient \"identifierType\" is unspecified");
+            }
+
+            if (string.IsNullOrEmpty(recipient.Address))
+            {
+                status.AddError("E405", "Recipient \"address\" is empty");
+            }
+
+            if (string.IsNullOrEmpty(document.Number))
+            {
+                if (numberAssignment == NumberAssignment.ExternalRequired)
+                {
+                    status.AddError("E405", $"{documentName} \"number\" is required by this device");
+                }
+            }
+            else if (numberAssignment == NumberAssignment.DeviceAssigned)
+            {
+                status.AddError("E412", $"External {documentName.ToLowerInvariant()} number is not supported by this device");
+            }
+        }
+
 
 
         public virtual DeviceStatus ValidateTransferAmount(TransferAmount transferAmount)

--- a/ErpNet.FP.Core/Drivers/BgSis/BgSisJsonFiscalPrinter.Commands.cs
+++ b/ErpNet.FP.Core/Drivers/BgSis/BgSisJsonFiscalPrinter.Commands.cs
@@ -382,6 +382,61 @@ namespace ErpNet.FP.Core.Drivers.BgSis
             return prms;
         }
 
+        /// <summary>
+        /// Builds the "invoiceData" client block for an extended fiscal receipt (invoice or credit note).
+        /// </summary>
+        protected JObject BuildInvoiceData(IInvoiceDocument document)
+        {
+            var recipient = document.Recipient
+                ?? throw new StandardizedStatusMessageException("Invoice requires a \"recipient\"", "E405");
+
+            // invNumber is caller-supplied and mandatory in the SIS protocol.
+            if (string.IsNullOrEmpty(document.Number))
+            {
+                throw new StandardizedStatusMessageException("Invoice \"number\" is required by this device", "E405");
+            }
+
+            // The SIS module requires the city as a field of its own, separate from the address.
+            if (string.IsNullOrEmpty(recipient.City))
+            {
+                throw new StandardizedStatusMessageException("Recipient \"city\" is required by this device", "E405");
+            }
+
+            var data = new JObject
+            {
+                ["invNumber"] = document.Number,
+                ["city"] = recipient.City,
+                ["identNumber"] = recipient.Identifier,
+                ["identNumberType"] = GetIdentifierTypeCode(recipient.IdentifierType),
+                ["recipientAddress"] = recipient.Address,
+                ["recipientName"] = recipient.Name
+            };
+
+            if (!string.IsNullOrEmpty(recipient.VatNumber))
+            {
+                data["vatIdentNumber"] = recipient.VatNumber;
+            }
+
+            return data;
+        }
+
+        /// <summary>
+        /// Maps the country-neutral <see cref="IdentifierType"/> to the SIS "identNumberType" code:
+        /// 0 = BG company, 1 = BG physical person, 2 = foreign company or physical person.
+        /// The SIS module has no code for a tax-authority number.
+        /// </summary>
+        protected static int GetIdentifierTypeCode(IdentifierType identifierType)
+        {
+            return identifierType switch
+            {
+                IdentifierType.LegalRegistration => 0,
+                IdentifierType.NationalId => 1,
+                IdentifierType.ForeignerId => 2,
+                _ => throw new StandardizedStatusMessageException(
+                    $"Identifier type {identifierType} is not supported by this device", "E412")
+            };
+        }
+
         protected JObject BuildSaleItem(Item item)
         {
             var quantity = item.Quantity == 0m ? 1m : item.Quantity;

--- a/ErpNet.FP.Core/Drivers/BgSis/BgSisJsonFiscalPrinter.cs
+++ b/ErpNet.FP.Core/Drivers/BgSis/BgSisJsonFiscalPrinter.cs
@@ -13,6 +13,14 @@ namespace ErpNet.FP.Core.Drivers.BgSis
     /// <seealso cref="ErpNet.FP.Core.Drivers.BgFiscalPrinter" />
     public partial class BgSisJsonFiscalPrinter : BgFiscalPrinter
     {
+        // A "comment" line (emitted as freeprint before a sale, or as an item's textlines after one)
+        // accepts digits only in its first 31 characters; a digit further right is rejected by the
+        // device with EM_PARA_WRONG_FORMAT (0x5D). Validate it up front so the caller gets a clear
+        // message instead of the opaque device error. The rule is field-specific and verified live:
+        // it applies ONLY to comments - sale descriptions, footer comments (textAfterPayment) and
+        // subtotal-modifier text (subtotalText) are all exempt, so they must NOT be flagged.
+        private const int CommentDigitLimit = 31;
+
         public BgSisJsonFiscalPrinter(
             IChannel channel,
             ServiceOptions serviceOptions,
@@ -159,9 +167,100 @@ namespace ErpNet.FP.Core.Drivers.BgSis
             return PrintFiscalReceipt(reversalReceipt, reversalReceipt);
         }
 
-        public override DeviceStatus ValidateInvoice(Invoice invoice) => ValidateInvoiceCore(invoice);
+        public override DeviceStatus ValidateReceipt(Receipt receipt)
+        {
+            var status = base.ValidateReceipt(receipt);
+            if (status.Ok)
+            {
+                ValidateCommentDigits(status, receipt);
+            }
 
-        public override DeviceStatus ValidateCreditNote(CreditNote creditNote) => ValidateCreditNoteCore(creditNote);
+            return status;
+        }
+
+        protected static void ValidateCommentDigits(DeviceStatus status, Receipt receipt)
+        {
+            if (receipt.Items == null)
+            {
+                return;
+            }
+
+            var row = 0;
+            foreach (var item in receipt.Items)
+            {
+                row++;
+                if (item.Type != ItemType.Comment)
+                {
+                    continue;
+                }
+
+                for (var i = CommentDigitLimit; i < item.Text.Length; i++)
+                {
+                    if (char.IsDigit(item.Text[i]))
+                    {
+                        status.AddError("E403",
+                            $"Item {row}: a comment line accepts digits only in the first {CommentDigitLimit} characters");
+                        
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override DeviceStatus ValidateInvoice(Invoice invoice)
+        {
+            var status = ValidateInvoiceCore(invoice);
+            if (status.Ok)
+            {
+                ValidateSisRecipient(status, invoice.Recipient);
+            }
+
+            return status;
+        }
+
+        public override DeviceStatus ValidateCreditNote(CreditNote creditNote)
+        {
+            var status = ValidateCreditNoteCore(creditNote);
+
+            if (status.Ok)
+            {
+                ValidateSisRecipient(status, creditNote.Recipient);
+
+                if (string.IsNullOrEmpty(creditNote.FiscalDeviceSerialNumber))
+                {
+                    status.AddError("E405", "FiscalDeviceSerialNumber of the original invoice is required by this device");
+                }
+            }
+
+            return status;
+        }
+
+        /// <summary>
+        /// SIS-specific recipient checks not covered by the neutral validation: the device requires a
+        /// city as a separate field, and it can only encode a subset of identifier types. Reported here
+        /// so the caller gets a clear error up front instead of an opaque device error at print time.
+        /// </summary>
+        protected void ValidateSisRecipient(DeviceStatus status, Recipient? recipient)
+        {
+            if (recipient == null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(recipient.City))
+            {
+                status.AddError("E405", "Recipient \"city\" is required by this device");
+            }
+
+            try
+            {
+                GetIdentifierTypeCode(recipient.IdentifierType);
+            }
+            catch (StandardizedStatusMessageException e)
+            {
+                status.AddError(e.Code, e.Message);
+            }
+        }
 
         public override (ReceiptInfo, DeviceStatus) PrintInvoice(Invoice invoice)
         {

--- a/ErpNet.FP.Core/Drivers/BgSis/BgSisJsonFiscalPrinter.cs
+++ b/ErpNet.FP.Core/Drivers/BgSis/BgSisJsonFiscalPrinter.cs
@@ -159,6 +159,57 @@ namespace ErpNet.FP.Core.Drivers.BgSis
             return PrintFiscalReceipt(reversalReceipt, reversalReceipt);
         }
 
+        public override DeviceStatus ValidateInvoice(Invoice invoice) => ValidateInvoiceCore(invoice);
+
+        public override DeviceStatus ValidateCreditNote(CreditNote creditNote) => ValidateCreditNoteCore(creditNote);
+
+        public override (ReceiptInfo, DeviceStatus) PrintInvoice(Invoice invoice)
+        {
+            JObject prms;
+            try
+            {
+                prms = BuildReceiptParams(invoice, null);
+                prms["invoiceData"] = BuildInvoiceData(invoice);
+            }
+            catch (StandardizedStatusMessageException e)
+            {
+                return ErrorResult(e);
+            }
+
+            return ExecutePrint(prms, invoice, invoice.Number);
+        }
+
+        public override (ReceiptInfo, DeviceStatus) PrintCreditNote(CreditNote creditNote)
+        {
+            JObject prms;
+            try
+            {
+                prms = BuildReceiptParams(creditNote, creditNote);
+                var reversal = (JObject)prms["stornoInput"]!;
+                if (string.IsNullOrEmpty(creditNote.OriginalInvoiceNumber))
+                {
+                    throw new StandardizedStatusMessageException(
+                        "OriginalInvoiceNumber of the credit note is empty", "E405");
+                }
+
+                if (string.IsNullOrEmpty(creditNote.FiscalDeviceSerialNumber))
+                {
+                    throw new StandardizedStatusMessageException(
+                        "FiscalDeviceSerialNumber of the original invoice is required by this device", "E405");
+                }
+
+                reversal["invoiceNumber"] = creditNote.OriginalInvoiceNumber;
+                reversal["fiscDevNumber"] = creditNote.FiscalDeviceSerialNumber;
+                prms["invoiceData"] = BuildInvoiceData(creditNote);
+            }
+            catch (StandardizedStatusMessageException e)
+            {
+                return ErrorResult(e);
+            }
+
+            return ExecutePrint(prms, creditNote, creditNote.Number);
+        }
+
         protected (ReceiptInfo, DeviceStatus) PrintFiscalReceipt(Receipt receipt, ReversalReceipt? reversal)
         {
             JObject prms;
@@ -168,18 +219,47 @@ namespace ErpNet.FP.Core.Drivers.BgSis
             }
             catch (StandardizedStatusMessageException e)
             {
-                var s = new DeviceStatus();
-                s.AddError(e.Code, e.Message);
-                return (new ReceiptInfo(), s);
+                return ErrorResult(e);
             }
 
+            return ExecutePrint(prms, receipt, null);
+        }
+
+        /// <summary>
+        /// Sends the built printReceipt request and resolves the returned receipt info. When
+        /// <paramref name="invoiceNumber"/> is non-null the result is an <see cref="InvoiceInfo"/>
+        /// carrying that number (invoice / credit note); otherwise a plain <see cref="ReceiptInfo"/>.
+        /// </summary>
+        protected (ReceiptInfo, DeviceStatus) ExecutePrint(JObject prms, Receipt receipt, string? invoiceNumber)
+        {
             var (json, status) = Request("printReceipt", prms);
             if (!status.Ok)
             {
                 return (new ReceiptInfo(), status);
             }
 
-            return EnrichReceiptInfo(json, status, receipt);
+            var (info, enrichedStatus) = EnrichReceiptInfo(json, status, receipt);
+
+            if (invoiceNumber != null)
+            {
+                info = new InvoiceInfo
+                {
+                    ReceiptNumber = info.ReceiptNumber,
+                    ReceiptDateTime = info.ReceiptDateTime,
+                    ReceiptAmount = info.ReceiptAmount,
+                    FiscalMemorySerialNumber = info.FiscalMemorySerialNumber,
+                    InvoiceNumber = invoiceNumber
+                };
+            }
+
+            return (info, enrichedStatus);
+        }
+
+        private static (ReceiptInfo, DeviceStatus) ErrorResult(StandardizedStatusMessageException e)
+        {
+            var status = new DeviceStatus();
+            status.AddError(e.Code, e.Message);
+            return (new ReceiptInfo(), status);
         }
 
         /// <summary>

--- a/ErpNet.FP.Core/Drivers/BgSis/BgSisJsonFiscalPrinterDriver.cs
+++ b/ErpNet.FP.Core/Drivers/BgSis/BgSisJsonFiscalPrinterDriver.cs
@@ -42,6 +42,12 @@ namespace ErpNet.FP.Core.Drivers.BgSis
                 // the extra flag tells callers that taxGroup is mandatory here for such items.
                 fiscalPrinter.Info.SupportsSubTotalAmountModifiers = true;
                 fiscalPrinter.Info.SubTotalAmountModifiersRequireTaxGroup = true;
+                // The SIS module prints extended fiscal receipts (invoice / Credit Memo). The number
+                // (invNumber) must always be supplied by the caller (>= 1); the device never assigns it.
+                fiscalPrinter.Info.SupportsInvoice = true;
+                fiscalPrinter.Info.SupportsCreditNote = true;
+                fiscalPrinter.Info.InvoiceNumberAssignment = NumberAssignment.ExternalRequired;
+                fiscalPrinter.Info.CreditNoteNumberAssignment = NumberAssignment.ExternalRequired;
                 serviceOptions.ReconfigurePrinterConstants(fiscalPrinter.Info);
 
                 return fiscalPrinter;

--- a/ErpNet.FP.Core/Service/PrintJob.cs
+++ b/ErpNet.FP.Core/Service/PrintJob.cs
@@ -9,6 +9,8 @@
         RawRequest,
         Receipt,
         ReversalReceipt,
+        Invoice,
+        CreditNote,
         Withdraw,
         Deposit,
         XReport,
@@ -85,7 +87,7 @@
                             if (validateStatus.Ok)
                             {
                                 var (info, status) = Printer.PrintReceipt(receipt);
-                                Result = new DeviceStatusWithReceiptInfo(status, info);
+                                Result = info.ToDeviceStatus(status);
                             }
                             else
                             {
@@ -101,13 +103,45 @@
                             if (validateStatus.Ok)
                             {
                                 var (info, status) = Printer.PrintReversalReceipt(reversalReceipt);
-                                Result = new DeviceStatusWithReceiptInfo(status, info);
+                                Result = info.ToDeviceStatus(status);
                             }
                             else
                             {
                                 Result = validateStatus;
                             }
                         };
+                        break;
+                    case PrintJobAction.Invoice:
+                        if (Document != null)
+                        {
+                            var invoice = (Invoice)Document;
+                            var validateStatus = Printer.ValidateInvoice(invoice);
+                            if (validateStatus.Ok)
+                            {
+                                var (info, status) = Printer.PrintInvoice(invoice);
+                                Result = info.ToDeviceStatus(status);
+                            }
+                            else
+                            {
+                                Result = validateStatus;
+                            }
+                        }
+                        break;
+                    case PrintJobAction.CreditNote:
+                        if (Document != null)
+                        {
+                            var creditNote = (CreditNote)Document;
+                            var validateStatus = Printer.ValidateCreditNote(creditNote);
+                            if (validateStatus.Ok)
+                            {
+                                var (info, status) = Printer.PrintCreditNote(creditNote);
+                                Result = info.ToDeviceStatus(status);
+                            }
+                            else
+                            {
+                                Result = validateStatus;
+                            }
+                        }
                         break;
                     case PrintJobAction.Withdraw:
                         if (Document != null)

--- a/ErpNet.FP.Server/Controllers/PrintersController.cs
+++ b/ErpNet.FP.Server/Controllers/PrintersController.cs
@@ -187,6 +187,72 @@
             return NotFound();
         }
 
+        // POST {id}/invoice
+        [HttpPost("{id}/invoice")]
+        public async Task<IActionResult> PrintInvoice(
+            string id,
+            [FromBody] Invoice invoice,
+            [FromQuery] string? taskId,
+            [FromQuery] string? timeout,
+            [FromQuery] int asyncTimeout = PrintJob.DefaultTimeout)
+        {
+            if (!context.IsReady)
+            {
+                return StatusCode(StatusCodes.Status405MethodNotAllowed);
+            }
+
+            if (context.Printers.TryGetValue(id, out IFiscalPrinter? printer))
+            {
+                var result = await context.RunAsync(
+                    new PrintJob
+                    {
+                        Printer = printer,
+                        Action = PrintJobAction.Invoice,
+                        Document = invoice,
+                        AsyncTimeout = asyncTimeout,
+                        Timeout = timeout == null ? 0 : timeout.ParseTimeout(),
+                        TaskId = taskId
+                    });
+
+                return Ok(result);
+            }
+
+            return NotFound();
+        }
+
+        // POST {id}/creditnote
+        [HttpPost("{id}/creditnote")]
+        public async Task<IActionResult> PrintCreditNote(
+            string id,
+            [FromBody] CreditNote creditNote,
+            [FromQuery] string? taskId,
+            [FromQuery] string? timeout,
+            [FromQuery] int asyncTimeout = PrintJob.DefaultTimeout)
+        {
+            if (!context.IsReady)
+            {
+                return StatusCode(StatusCodes.Status405MethodNotAllowed);
+            }
+
+            if (context.Printers.TryGetValue(id, out IFiscalPrinter? printer))
+            {
+                var result = await context.RunAsync(
+                    new PrintJob
+                    {
+                        Printer = printer,
+                        Action = PrintJobAction.CreditNote,
+                        Document = creditNote,
+                        AsyncTimeout = asyncTimeout,
+                        Timeout = timeout == null ? 0 : timeout.ParseTimeout(),
+                        TaskId = taskId
+                    });
+
+                return Ok(result);
+            }
+
+            return NotFound();
+        }
+
         // POST {id}/withdraw
         [HttpPost("{id}/withdraw")]
         public async Task<IActionResult> PrintWithdraw(

--- a/ErpNet.FP.Setup/Product.wxs
+++ b/ErpNet.FP.Setup/Product.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-  <Package Name="ErpNet.FP - Fiscal Print Server" Language="1033" Version="1.1.0.1690" Manufacturer="Erp.Net And Contributors" UpgradeCode="05E58513-A8D9-45BF-A280-D47CCB696623" InstallerVersion="200">
+  <Package Name="ErpNet.FP - Fiscal Print Server" Language="1033" Version="1.1.0.1691" Manufacturer="Erp.Net And Contributors" UpgradeCode="05E58513-A8D9-45BF-A280-D47CCB696623" InstallerVersion="200">
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." AllowSameVersionUpgrades="yes" />
     <Property Id="MSIFASTINSTALL" Value="7" />
     <MediaTemplate EmbedCab="yes" />

--- a/ErrorCodes.md
+++ b/ErrorCodes.md
@@ -57,6 +57,8 @@ However, the "originalCode" might not always be available or it might change due
 * **E409** Wrong command response format
 * **E410** Document is empty or no items
 * **E411** Invalid tax group
+* **E412** Feature not supported by the device
+* **E413** Feature not implemented by the driver
 * **E499** Command general error
 
 ## NRA link error codes

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -17,6 +17,8 @@ The ErpNet.FP print server accepts documents for printing, using the JSON based 
 * `POST` [Print Fiscal Receipt (Idempotent)](#post-print-fiscal-receipt-idempotent)
 * `GET` [Get Async Task Information](#get-get-async-task-information)
 * `POST` [Print Reversal Receipt](#post-print-reversal-receipt)
+* `POST` [Print Invoice](#post-print-invoice)
+* `POST` [Print Credit Note](#post-print-credit-note)
 * `POST` [Print Deposit Money Receipt](#post-print-deposit-money-receipt)
 * `POST` [Print Withdraw Money Receipt](#post-print-withdraw-money-receipt)
 * `POST` [Print X Report](#post-print-x-report)
@@ -186,6 +188,12 @@ http://localhost:8001/printers/dy448967
 Depending on the device, the info may also contain capability flags:
 * **"supportsSubTotalAmountModifiers"** - whether the device supports receipt-level (subtotal) `discount-amount` / `surcharge-amount` items.
 * **"subTotalAmountModifiersRequireTaxGroup"** - when the above is true, whether each subtotal modifier item must also carry a **"taxGroup"** (VAT category).
+* **"supportsInvoice"** - whether the driver can print a native fiscal invoice on this device (see [Print Invoice](#post-print-invoice)).
+* **"supportsCreditNote"** - whether the driver can print a native credit note on this device (see [Print Credit Note](#post-print-credit-note)).
+* **"invoiceNumberAssignment"** / **"creditNoteNumberAssignment"** - how the invoice / credit note number is assigned. One of:
+* * **"device-assigned"** - the device generates the number; a caller-supplied **"number"** is rejected.
+* * **"external-optional"** - the caller may supply the **"number"**; when omitted, the device assigns it.
+* * **"external-required"** - the caller must supply the **"number"**.
 
 ## `GET` Get Printer Status
 Contacts the specific fiscal printer and returns its current status and current printer date and time.
@@ -552,6 +560,114 @@ The reversal receipt JSON input format is mostly the same as PrintReceipt. The c
 
 ### Response
 The same as PrintReceipt, except for the "info" section, which is not provided (not needed).
+
+## `POST` Print Invoice
+Prints a native fiscal invoice - an extended fiscal receipt that also carries a **recipient** (buyer) block.
+
+NOTE: Not every device/driver implements native invoices. Check **"supportsInvoice"** in the device info first. A request to a device that does not implement it returns an error with code **E413** ("not implemented by the driver"). The neutral field names below are translated by each driver to its own device specifics.
+
+### Example request uri:
+```
+http://localhost:8001/printers/zk126720/invoice
+```
+
+The JSON input is the same as [Print Fiscal Receipt](#post-print-fiscal-receipt) (`uniqueSaleNumber`, `items`, `payments`, optional `operator`/`operatorPassword`), plus the following fields:
+
+* **"recipient"** - the buyer party (required). Its fields:
+* * **"name"** - buyer legal / registered name (required).
+* * **"identifier"** - buyer registration identifier, e.g. company registration number (required).
+* * **"identifierType"** - the kind of identifier (required). One of: **"legal-registration"**, **"national-id"**, **"foreigner-id"**, **"tax-number"**. Not every device can encode every type - an unsupported type is rejected with code **E412**.
+* * **"vatNumber"** - buyer VAT identifier (optional; leave empty when the buyer is not VAT registered).
+* * **"address"** - buyer postal address (required).
+* * **"city"** - buyer city / town. Some devices require it as a separate field (e.g. SIS); others fold the city into the address.
+* **"receiver"** - *(optional)* the person on the buyer side who received the goods / services (a signature line on the printed invoice). Device-dependent - printed only by devices whose protocol has a dedicated field for it; the SIS driver does not emit it.
+* **"issuer"** - *(optional)* the person on the seller side who drew up the invoice. Device-dependent, same as **"receiver"**.
+* **"number"** - the invoice number. Its handling depends on the device's **"invoiceNumberAssignment"** (see device info): required for **"external-required"**, optional for **"external-optional"**, and rejected (with **E412**) for **"device-assigned"**.
+
+### Example request body:
+```json
+{
+  "uniqueSaleNumber": "ZK126720-0001-0000001",
+  "recipient": {
+    "name": "SIS TECHNOLOGY AD",
+    "identifier": "200510279",
+    "identifierType": "legal-registration",
+    "vatNumber": "BG200510279",
+    "address": "bul. Tsarigradsko Shose 60",
+    "city": "Sofia"
+  },
+  "number": "9000000007",
+  "items": [
+    {
+      "text": "Cheese",
+      "quantity": 1,
+      "unitPrice": 12,
+      "taxGroup": 2
+    }
+  ],
+  "payments": [
+    {
+      "amount": 12,
+      "paymentType": "cash"
+    }
+  ]
+}
+```
+
+### Response
+The same as [Print Fiscal Receipt](#post-print-fiscal-receipt), plus:
+* **"invoiceNumber"** - the invoice number as actually printed: the caller-supplied value for external numbering, or the device-assigned value otherwise.
+
+## `POST` Print Credit Note
+Prints a native credit note - an extended fiscal reversal against an original invoice, carrying the same **recipient** (buyer) block as an invoice.
+
+NOTE: Check **"supportsCreditNote"** in the device info first; a device that does not implement it returns **E413**.
+
+### Example request uri:
+```
+http://localhost:8001/printers/zk126720/creditnote
+```
+
+The input combines [Print Reversal Receipt](#post-print-reversal-receipt) (it references the original document) with the invoice **"recipient"** block. Fields in addition to Print Reversal Receipt:
+
+* **"recipient"**, **"receiver"**, **"issuer"** - the same buyer block as [Print Invoice](#post-print-invoice).
+* **"number"** - the credit note's own number (handled per **"creditNoteNumberAssignment"**, same rules as the invoice number).
+* **"originalInvoiceNumber"** - the number of the original invoice being credited (required). This is distinct from **"receiptNumber"** (the original fiscal receipt number).
+* **"fiscalDeviceSerialNumber"** - the serial number of the fiscal device that issued the original invoice. Required by some devices (e.g. SIS); distinct from **"fiscalMemorySerialNumber"**.
+* Inherited from Print Reversal Receipt: **"uniqueSaleNumber"** (same as the original), **"receiptNumber"**, **"receiptDateTime"**, **"fiscalMemorySerialNumber"**, **"reason"**.
+
+### Example request body:
+```json
+{
+  "uniqueSaleNumber": "ZK126720-0001-0000001",
+  "recipient": {
+    "name": "SIS TECHNOLOGY AD",
+    "identifier": "200510279",
+    "identifierType": "legal-registration",
+    "vatNumber": "BG200510279",
+    "address": "bul. Tsarigradsko Shose 60",
+    "city": "Sofia"
+  },
+  "number": "9000000008",
+  "originalInvoiceNumber": "9000000007",
+  "receiptNumber": "0000000137",
+  "receiptDateTime": "2026-07-15T11:54:10",
+  "fiscalMemorySerialNumber": "51026679",
+  "fiscalDeviceSerialNumber": "BN025335",
+  "reason": "refund",
+  "items": [
+    {
+      "text": "Cheese",
+      "quantity": 1,
+      "unitPrice": 12,
+      "taxGroup": 2
+    }
+  ]
+}
+```
+
+### Response
+The same as [Print Invoice](#post-print-invoice) - includes **"invoiceNumber"** (here, the credit note number).
 
 ## `POST` Print Deposit Money Receipt
 Deposits the amount

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -576,7 +576,13 @@ The JSON input is the same as [Print Fiscal Receipt](#post-print-fiscal-receipt)
 * **"recipient"** - the buyer party (required). Its fields:
 * * **"name"** - buyer legal / registered name (required).
 * * **"identifier"** - buyer registration identifier, e.g. company registration number (required).
-* * **"identifierType"** - the kind of identifier (required). One of: **"legal-registration"**, **"national-id"**, **"foreigner-id"**, **"tax-number"**. Not every device can encode every type - an unsupported type is rejected with code **E412**.
+* * **"identifierType"** - the kind of identifier (required). It **must match the buyer**: the device validates **"identifier"** against this type and rejects the whole document if they do not agree (e.g. a foreign number declared as a domestic one). One of:
+* * * **"legal-registration"** - a **domestic (resident) company**; **"identifier"** must be a valid domestic company registration number (on Bulgarian devices, a numeric ЕИК / Bulstat).
+* * * **"national-id"** - a **domestic (resident) individual**; **"identifier"** must be a valid national id (on Bulgarian devices, an ЕГН).
+* * * **"foreigner-id"** - a **foreign (non-resident) company or individual**; **"identifier"** may be alphanumeric. Use this for any non-domestic buyer, whether a company or a person.
+* * * **"tax-number"** - a tax-authority-issued number. Not supported by every device (rejected with **E412** where unsupported - e.g. the SIS driver).
+
+Not every device can encode every type; an unsupported type is rejected with code **E412**.
 * * **"vatNumber"** - buyer VAT identifier (optional; leave empty when the buyer is not VAT registered).
 * * **"address"** - buyer postal address (required).
 * * **"city"** - buyer city / town. Some devices require it as a separate field (e.g. SIS); others fold the city into the address.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,14 @@ If you want your device to be supported, please contact us, and we will try our 
 
 * **Didn't find your device on the list?** Please, create an issue here in the project and we will check whether we can support it with the current set of protocols or we need to implement a new one.
 
+## Native invoices and credit notes
+
+The server can print **native fiscal invoices** and **credit notes** (extended fiscal receipts that carry a buyer/recipient block) via the `POST /printers/{id}/invoice` and `POST /printers/{id}/creditnote` endpoints. See the [protocol documentation](PROTOCOL.md#post-print-invoice) for the request format, and a printer's `supportsInvoice` / `supportsCreditNote` device-info flags for availability.
+
+Currently this is **implemented only for the SIS driver (`bg.sis.json`)**.
+
+All the other supported Bulgarian fiscal devices also support native invoices and credit notes **at the device/protocol level** (confirmed against their manufacturer specifications - the ISL family via its "invoice data" command, Tremol ZFP via its fiscal-invoice commands, etc.), but the ErpNet.FP drivers do not map them **yet**. Until they do, those devices report `supportsInvoice` / `supportsCreditNote` as `false` and the two endpoints return error code **E413** ("feature not implemented by the driver"). Contributions and requests to implement the remaining drivers are welcome - please open an issue.
+
 ## Default passwords we use in the library.
 This is a list of default credentials we use in the library, when there is no exclusive override of the values in the Json fields "operator" and "operatorPassword", while you make a Json requests to the fiscal device.
 * bg.dt.c.isl - "operator" : "1", "operatorPassword": "1"

--- a/output.xml
+++ b/output.xml
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <OutputPath>Output</OutputPath>
         <PublishRoot>Published</PublishRoot>
-        <Version>1.1.0.1690</Version>
+        <Version>1.1.0.1691</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Adds `POST /printers/{id}/invoice` and `POST /printers/{id}/creditnote`, reusing the core print pipeline.
* **Country-neutral model** - `Invoice`, `CreditNote`, `Recipient`;
* **Capability flags** on `DeviceInfo` (`SupportsInvoice` / `SupportsCreditNote`, `...NumberAssignment`) so clients can discover support up front.
* **Typed dispatch** (`PrintInvoice` / `ValidateInvoice`/...) with new error codes **E412** (unsupported by device) / **E413** (not implemented by driver).
* **BgSis (SIS)** fully implemented and verified on live hardware, with pre-flight validation for clear errors. Other drivers advertise `false` / return **E413** (not yet wired up).